### PR TITLE
Three small changes which could end the page design CSS code move

### DIFF
--- a/CompSci/index.html
+++ b/CompSci/index.html
@@ -3,7 +3,16 @@
     perspective: 600px;
     rotateY(30);
   }
+	body {
+  		background-color: #222222;
+  		color: #EEEEEE;
+  		font-family: Verdana, sans-serif;
+	}
+	.active {
+		background-color: #0033cc
+	}
 </style>
+<link rel="stylesheet" type="text/css" href="https://magnogen.github.io/src/style.css">
 
 <html>
   <head>

--- a/QandA/index.html
+++ b/QandA/index.html
@@ -5,41 +5,16 @@
     </title>
   </head>
   <style>
-		body {
-			background-color: #222222;
-			color: #eeeeee;
-			font-family: Verdana, sans-serif;
-		}
-		ul {
-			list-style-type: none;
-			margin: 0;
-			padding: 0;
-			overflow: hidden;
-			background-color: #333333;
-			position: fixed;
-			top: 0;
-			width: 100%;
-		}
-		li {
-		    	float: left;
-		}
-		li a {
-		    	display: block;
-		    	color: white;
-		    	text-align: center;
-		    	padding: 14px 16px;
-		    	text-decoration: none;
-		}
-		li a:hover:not(.active) {
-		    	background-color: #111111;
-		}
-		.active {
-		    	background-color: #4CAF50;
-		}
-	  	.Q {
-			color: lightgreen
-	  	}
-  </style>
+  body {
+    background-color: #222222;
+    color: #EEEEEE;
+    font-family: Verdana, sans-serif;
+  }
+  .active {
+  background-color: #0033cc
+  }
+</style>
+<link rel="stylesheet" type="text/css" href="https://magnogen.github.io/src/style.css">
   <body>
 		<ul>
   			<li>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   			font-family: Verdana, sans-serif;
 		}
 		.active {
-			background-color: #0000FF
+			background-color: #0033cc
 		}
 	</style>
 	<link rel="stylesheet" type="text/css" href="https://magnogen.github.io/src/style.css">


### PR DESCRIPTION
Update my repository fork for 3 more small changes, to remove the old page design CSS code that's now part of a linked external stylesheet file.
Style code for the body tag and background colour of active navigation links (see my comment) was also added where needed. It would be good if this finishes the code move and username change.